### PR TITLE
Fix theme toggle handler duplication

### DIFF
--- a/src/components/ThemeIcon.astro
+++ b/src/components/ThemeIcon.astro
@@ -44,7 +44,7 @@
     const themeToggle = document.getElementById("themeToggle");
 
     if (themeToggle) {
-      themeToggle.addEventListener("click", () => {
+      themeToggle.onclick = () => {
         // Add animation class
         document.documentElement.classList.add("theme-transition");
 
@@ -59,7 +59,7 @@
         setTimeout(() => {
           document.documentElement.classList.remove("theme-transition");
         }, 500);
-      });
+      };
     }
   }
 


### PR DESCRIPTION
## Summary
- assign the click handler directly on `themeToggle` so it is replaced instead of added repeatedly

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68515336ee90832bbcb119ceab6e8d9c